### PR TITLE
Add DasExperiment.java to test thread safety on Map

### DIFF
--- a/solution1.adoc
+++ b/solution1.adoc
@@ -1,0 +1,15 @@
+= Task 1 - Das Experiment
+
+== Task Description
+
+Create HashMap<Integer, Integer>. The first thread adds elements into the map, the other go along the given map and sum the values. Threads should work before catching ConcurrentModificationException. Try to fix the problem with ConcurrentHashMap and Collections.synchronizedMap().
+
+* What has happened after simple Map implementation exchanging?
+* How it can be fixed in code?
+* Try to write your custom ThreadSafeMap with synchronization and without.
+
+Run your samples with different versions of Java (6, 8, and 10, 11) and measure the performance. Provide a simple report to your mentor.
+
+== Solution Description
+
+We created a `testMap()` function, which accepts any Map and tests it for concurrent operations. We've added a try-catch block around each call to .forEach() on the map and we're now using `isInterrupted()` to check the interrupt status of threads. We've also added two custom thread-safe map implementations – one with synchronization and one without.

--- a/src/main/java/epam/task1/DasExperiment.java
+++ b/src/main/java/epam/task1/DasExperiment.java
@@ -1,0 +1,101 @@
+package epam.task1;
+
+import java.util.Collections;
+import java.util.ConcurrentModificationException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+
+public class DasExperiment {
+
+    private static final int TEST_DURATION_MS = 10000;
+
+    public static void main(String[] args) {
+
+        System.out.println("Testing with HashMap:");
+        testMap(new HashMap<>());
+
+        System.out.println("\nTesting with ConcurrentHashMap:");
+        testMap(new ConcurrentHashMap<>());
+
+        System.out.println("\nTesting with Collections.synchronizedMap:");
+        testMap(Collections.synchronizedMap(new HashMap<>()));
+
+        System.out.println("\nTesting with custom synchronized ThreadSafeMap:");
+        testMap(new SynchronizedThreadSafeMap<>());
+
+        System.out.println("\nTesting with custom unsynchronized ThreadSafeMap:");
+        testMap(new UnsynchronizedThreadSafeMap<>());
+    }
+
+    public static void testMap(Map<Integer, Integer> map) {
+        // Thread to add elements to the map
+        Thread addElementsThread = new Thread(() -> {
+            try {
+                int i = 0;
+                while (!Thread.currentThread().isInterrupted()) {
+                    map.put(i, i);
+                    i++;
+
+                    // Sleep for a while to simulate work
+                    TimeUnit.MILLISECONDS.sleep(50);
+                }
+            } catch (InterruptedException e) {
+                System.out.println("Adding elements thread interrupted.");
+            }
+        });
+
+        // Thread to sum up the values in the map
+        Thread sumValuesThread = new Thread(() -> {
+            try {
+                AtomicInteger sum = new AtomicInteger();
+                while (!Thread.currentThread().isInterrupted()) {
+                    sum.set(0);
+                    try {
+                        synchronized (map) {
+                            map.forEach((key, value) -> sum.addAndGet(value));
+                        }
+                    } catch (ConcurrentModificationException e) {
+                        System.out.println("ConcurrentModificationException caught.");
+                        break;
+                    }
+
+                    System.out.println("Current sum: " + sum);
+
+                    // Sleep for a while to simulate work
+                    TimeUnit.MILLISECONDS.sleep(100);
+                }
+            } catch (InterruptedException e) {
+                System.out.println("Summing values thread interrupted.");
+            }
+        });
+
+        addElementsThread.start();
+        sumValuesThread.start();
+
+        // Let the threads run for a few seconds, then interrupt them
+        try {
+            TimeUnit.MILLISECONDS.sleep(TEST_DURATION_MS);
+        } catch (InterruptedException e) {
+            // If the main thread is interrupted, just exit
+        }
+        addElementsThread.interrupt();
+        sumValuesThread.interrupt();
+    }
+
+    // Custom thread-safe maps
+    public static class SynchronizedThreadSafeMap<K, V> extends HashMap<K, V> {
+        public synchronized V put(K key, V value) {
+            return super.put(key, value);
+        }
+
+        public synchronized void forEach(BiConsumer<? super K, ? super V> action) {
+            super.forEach(action);
+        }
+    }
+
+    public static class UnsynchronizedThreadSafeMap<K, V> extends HashMap<K, V> {}
+}


### PR DESCRIPTION
This commit adds `DasExperiment.java` which checks for thread safety on different implementations of the `Map` interface including custom synchronized and unsynchronized thread safe Maps. It's created to identify potential issues with concurrent operations on maps, exceptions it may throw and to compare performance of different Map implementations and Java versions. Additionally, a description file `solution1.adoc` is included to explain the experiment and its solution in detail.