### PR TITLE
Add BlockingObjectPool class and its description

### DIFF
--- a/solution4.adoc
+++ b/solution4.adoc
@@ -1,0 +1,25 @@
+= Task 4: Blocking Object Pool
+
+== Task Description
+
+The goal of this task is to create a simple object pool with support for a multithreaded environment. The pool should block if it has no available items or is full. The requirements are as follows:
+
+* Implement a `BlockingObjectPool` class with a constructor that accepts the size of the pool as an argument.
+* Implement a `get()` method that returns an object from the pool or blocks if the pool is empty.
+* Implement a `take(Object object)` method that puts an object back into the pool or blocks if the pool is full.
+* Ensure that the implementation is thread-safe and uses any blocking approach.
+
+== Solution Description
+
+Our solution uses a `LinkedBlockingQueue` to implement the object pool. When the `BlockingObjectPool` is created, the queue is initialized with the specified size and filled with new `Object` instances. The `LinkedBlockingQueue` provides blocking behavior internally, ensuring that our implementation is thread-safe and efficient.
+
+Here is the implementation of the `BlockingObjectPool` class:
+
+[source,java]
+----
+include::src/main/java/epam/task4/BlockingObjectPool.java[]
+----
+
+The `get()` method retrieves an object from the pool and blocks if the pool is empty until an object becomes available. Similarly, the `take(...)` method puts an object into the pool and blocks if the pool is full until there is space available. Both methods use the blocking methods of the `LinkedBlockingQueue`, namely `take()` and `put(...)`, which handle blocking and signaling internally.
+
+If an interruption occurs during the `get()` or `take(...)` operations, the interrupted status of the current thread is preserved, allowing the caller to handle the interruption accordingly.

--- a/src/main/java/epam/task4/BlockingObjectPool.java
+++ b/src/main/java/epam/task4/BlockingObjectPool.java
@@ -1,0 +1,36 @@
+package epam.task4;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class BlockingObjectPool {
+
+    private final LinkedBlockingQueue<Object> pool;
+
+    public BlockingObjectPool(int size) {
+        pool = new LinkedBlockingQueue<>(size);
+        for (int i = 0; i < size; i++) {
+            pool.offer(new Object());
+        }
+    }
+
+    public Object get() {
+        try {
+            return pool.take();
+        } catch (InterruptedException e) {
+            // Restore the interrupted status of the thread after handling the InterruptedException
+            Thread.currentThread().interrupt();
+            // We return null here as an indication that the get operation was interrupted;
+            // this should be handled by the caller accordingly (e.g., by retrying or abandoning the operation)
+            return null;
+        }
+    }
+
+    public void take(Object object) {
+        try {
+            pool.put(object);
+        } catch (InterruptedException e) {
+            // Restore the interrupted status of the thread after handling the InterruptedException
+            Thread.currentThread().interrupt();
+        }
+    }
+}


### PR DESCRIPTION
Created a new class BlockingObjectPool, that provides thread-safe object pooling functionality. This class supports blocking when the pool is empty or full. The LinkedBlockingQueue is used to hold the pooled objects which also supports thread-safe blocking. The interruption handling mechanism was added for get and put methods to maintain the interrupted status of the thread during operation interruptions. Also added a detailed explanation of the implementation to solution4.adoc.